### PR TITLE
CPU Nounce Brute-forcer

### DIFF
--- a/miner/block.py
+++ b/miner/block.py
@@ -19,17 +19,19 @@ class Block:
                                     block
         :param time:                Unix time since epoch in seconds
         :param difficulty:          Packed representation (bits) of the current
-                                    network's difficulty
+                                    network's difficulty as an integer
         """
+        assert(type(previous_block_hash) == bytes)
+        assert(type(difficulty) == int)
+        assert(len(previous_block_hash) == 32)
+        assert(len(merkle_tree.root) == 32)
+
         self.version = Block.VERSION
         self.previous_block_hash = previous_block_hash
         self.merkle_tree = merkle_tree
         self.time = time
         self.difficulty = difficulty
         self.nounce = 0
-
-        assert(len(self.previous_block_hash) == 32)
-        assert(len(self.merkle_tree.root) == 32)
 
     def serialize_header(self):
         """
@@ -38,9 +40,9 @@ class Block:
         This is the chunk of bytes that we want to hash in our search for a
         valid hash.
         """
-        return (pack("<i", self.version) +
+        return (pack("<I", self.version) +
                 to_internal_byte_order(self.previous_block_hash) +
                 to_internal_byte_order(self.merkle_tree.root) +
-                pack("<i", self.time) +
-                pack("<i", self.difficulty) +
-                pack("<i", self.nounce))
+                pack("<I", self.time) +
+                pack("<I", self.difficulty) +
+                pack("<I", self.nounce))

--- a/miner/block.py
+++ b/miner/block.py
@@ -31,7 +31,7 @@ class Block:
         self.merkle_tree = merkle_tree
         self.time = time
         self.difficulty = difficulty
-        self.nounce = 0
+        self.nounce = None
 
     def serialize_header(self):
         """

--- a/miner/block_test.py
+++ b/miner/block_test.py
@@ -54,8 +54,9 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(header, b.serialize_header())
 
     def test_serialize_header_unsigned_ints(self):
-        # must support high nounces
-
+        """
+        Verifies that we support high nounces.
+        """
         tree = TestBlock.MerkleTreeMock()
         prev = to_rpc_byte_order(bytes([12] * 32))
         time = 0x12121212

--- a/miner/block_test.py
+++ b/miner/block_test.py
@@ -50,3 +50,18 @@ class TestBlock(unittest.TestCase):
         )
 
         self.assertEqual(header, b.serialize_header())
+
+    def test_serialize_header_unsigned_ints(self):
+        # must support high nounces
+
+        tree = TestBlock.MerkleTreeMock()
+        prev = to_rpc_byte_order(bytes([12] * 32))
+        time = 0x12121212
+        target = 0x12121212
+        nounce = 0xFFFFFFFF
+
+        b = Block(prev, tree, time, target)
+        b.nounce = nounce
+
+        b.serialize_header()
+        # no exception raised -> success

--- a/miner/block_test.py
+++ b/miner/block_test.py
@@ -14,6 +14,7 @@ class TestBlock(unittest.TestCase):
         tree = TestBlock.MerkleTreeMock()
         time = 432432
         bits = 0x1a44b9f2
+        nounce = None
 
         b = Block(prev, tree, time, bits)
 
@@ -22,6 +23,7 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(tree, b.merkle_tree)
         self.assertEqual(time, b.time)
         self.assertEqual(bits, b.difficulty)
+        self.assertEqual(nounce, b.nounce)
 
     def test_serialize_header(self):
         # example taken from:

--- a/miner/cpu_miner.py
+++ b/miner/cpu_miner.py
@@ -1,0 +1,15 @@
+from hashlib import sha256
+
+
+def mine(block, target, start=0, end=0xFFFFFFFF):
+    for nounce in range(start, end+1):
+        block.nounce = nounce
+        header = block.serialize_header()
+        hash_ = sha256(sha256(header).digest()).digest()
+
+        value = int.from_bytes(hash_, byteorder='little', signed=False)
+
+        if value <= target:
+            return
+
+    block.nounce = None

--- a/miner/cpu_miner.py
+++ b/miner/cpu_miner.py
@@ -2,6 +2,22 @@ from hashlib import sha256
 
 
 def mine(block, target, start=0, end=0xFFFFFFFF):
+    """
+    Searches the nounce integer space ([start,end]) for one that will produce a
+    block with a hash under the given target.
+
+    If a valid hash is found, `block.nounce` will contain the nounce that
+    produces that hash.
+    If none is found, `block.nounce` will be `None`.
+
+    :param block:  Block that we want a valid hash for.
+                   `block.nounce` will contain the found hash (or None).
+    :param target: Target value for the hash as an integer. If a hash is found,
+                   it will be less than equal that value.
+    :param start:  starting value for the nounce search
+    :param end:    final value for the nounce search
+    """
+    assert(end >= start)
     for nounce in range(start, end+1):
         block.nounce = nounce
         header = block.serialize_header()

--- a/miner/cpu_miner_test.py
+++ b/miner/cpu_miner_test.py
@@ -1,0 +1,42 @@
+import unittest
+
+from block import Block
+from cpu_miner import mine
+
+
+class TestCpuMiner(unittest.TestCase):
+    # Based on 00000000000000001e8d6829a8a21adc5d38d0a473b144b6765798e61f98bd1d
+    # (block at height 125552 in Mainchain)
+    class MerkleTreeMock:
+        def __init__(self):
+            self.root = bytes.fromhex(
+                "2b12fcf1b09288fcaff797d71e950e71"
+                "ae42b91e8bdb2304758dfcffc2b620e3"
+            )
+    target = 0x44b9f20000000000000000000000000000000000000000000000
+
+    def _fake_block(self):
+        prev = bytes.fromhex(
+            "00000000000008a3a41b85b8b29ad444def299fee21793cd8b9e567eab02cd81"
+        )
+        tree_mock = TestCpuMiner.MerkleTreeMock()
+        block = Block(prev, tree_mock, 0x4dd7f5c7, 0x1a44b9f2)
+        block.version = 1
+        return block
+
+    def test_mine_successful(self):
+        nounce = 0x9546a142
+        block = self._fake_block()
+
+        mine(block, TestCpuMiner.target,
+             start=nounce-100, end=nounce+100)
+        self.assertEqual(nounce, block.nounce)
+
+    def test_mine_unsuccessful(self):
+        bad_nounce = 0x12121212
+        block = self._fake_block()
+        block.nounce = bad_nounce
+
+        mine(block, TestCpuMiner.target,
+             start=bad_nounce, end=bad_nounce)
+        self.assertEqual(None, block.nounce)


### PR DESCRIPTION
Simple `for`-loop on the CPU that searches the 32-bits integer space for a nounce that produces a valid hash.

Minor:
- Fix bug in `Block` where it wouldn't allow big nounces (those that cross the distinction between `signed` and `unsigned` 32 bits)
- Add checks and tests to `Block` to help spot issues earlier
