### PR TITLE
Fix Coveralls and Add README Badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python: 3.5
 
+before_install: cd miner
 install:
-  - make -C miner install
+  - make install
 script:
-  - make -C miner test
-  - make -C miner coverage
+  - make test
+  - make coverage
 after_success:
-  - coveralls --base_dir miner
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Bitcoin Mining Pool
 
 [![Build Status](https://travis-ci.org/DrPandemic/pickaxe.svg?branch=master)](https://travis-ci.org/DrPandemic/pickaxe)
+[![Coverage Status](https://coveralls.io/repos/github/DrPandemic/pickaxe/badge.svg?branch=coveralls)](https://coveralls.io/github/DrPandemic/pickaxe?branch=coveralls)
+[![Code Climate](https://codeclimate.com/github/DrPandemic/pickaxe/badges/gpa.svg)](https://codeclimate.com/github/DrPandemic/pickaxe)
 
 ## Miner
 ### Install

--- a/miner/requirements.txt
+++ b/miner/requirements.txt
@@ -1,2 +1,2 @@
 coverage
-python-coveralls
+coveralls


### PR DESCRIPTION
- Switched `coveralls` python library
- Added coveralls and code-climate badges to README
- Changed `travis.yml` file to `cd` into `miner` folder

[Coverage now confirmed to work](https://coveralls.io/builds/5635439).
