### PR TITLE
Serialize Block

### DIFF
--- a/miner/block.py
+++ b/miner/block.py
@@ -1,6 +1,6 @@
 from struct import pack
 
-from helpers import to_internal_byte_order
+from helpers import to_internal_byte_order, encode_var_int
 
 
 class Block:
@@ -46,3 +46,17 @@ class Block:
                 pack("<I", self.time) +
                 pack("<I", self.difficulty) +
                 pack("<I", self.nounce))
+
+    def serialize(self):
+        """
+        Serialize the block into a chunk of data that can be submited to the
+        bitcoin client.
+        """
+        serialized = bytearray()
+
+        serialized.extend(self.serialize_header())
+        serialized.extend(encode_var_int(len(self.merkle_tree.transactions)))
+        for tx in self.merkle_tree.transactions:
+            serialized.extend(tx.data)
+
+        return bytes(serialized)

--- a/miner/helpers.py
+++ b/miner/helpers.py
@@ -1,3 +1,6 @@
+from struct import pack
+
+
 def to_internal_byte_order(rpc_byte_order):
     """
     Returns a given RPC byte order hash (bytes) to the format expected by
@@ -12,3 +15,21 @@ def to_rpc_byte_order(internal_byte_order):
     the RPC client.
     """
     return internal_byte_order[::-1]
+
+
+def encode_var_int(n):
+    """
+    Encodes an unsigned integer as a variable integer format.
+
+    See:
+    https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer
+    """
+
+    if n < 0xFD:
+        return pack("<B", n)
+    elif n <= 0xFFFF:
+        return bytes([0xFD]) + pack("<H", n)
+    elif n <= 0xFFFFFFFF:
+        return bytes([0xFE]) + pack("<I", n)
+    else:
+        return bytes([0xFF]) + pack("<Q", n)

--- a/miner/helpers_test.py
+++ b/miner/helpers_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from helpers import to_internal_byte_order, to_rpc_byte_order
+from helpers import to_internal_byte_order, to_rpc_byte_order, encode_var_int
 
 
 class TestHelpers(unittest.TestCase):
@@ -18,3 +18,28 @@ class TestHelpers(unittest.TestCase):
     def test_to_rpc_byte_order(self):
         rpc_order = to_rpc_byte_order(TestHelpers.internal_byte_order)
         self.assertEqual(TestHelpers.rpc_order, rpc_order)
+
+    def test_encode_var_int_0(self):
+        self.assertEqual(bytes([0]), encode_var_int(0))
+
+    def test_encode_var_int_0xFC(self):
+        self.assertEqual(bytes([0xFC]), encode_var_int(0xFC))
+
+    def test_encode_var_int_0xFD(self):
+        self.assertEqual(bytes([0xFD, 0xFD, 0x00]), encode_var_int(0xFD))
+
+    def test_encode_var_int_0xFFFF(self):
+        self.assertEqual(bytes([0xFD, 0xFF, 0xFF]), encode_var_int(0xFFFF))
+
+    def test_encode_var_int_0x10000(self):
+        expected = bytes([0xFE, 0x00, 0x00, 0x01, 0x00])
+        self.assertEqual(expected, encode_var_int(0x10000))
+
+    def test_encode_var_int_0xFFFFFFFF(self):
+        expected = bytes([0xFE, 0xFF, 0xFF, 0xFF, 0xFF])
+        self.assertEqual(expected, encode_var_int(0xFFFFFFFF))
+
+    def test_encode_var_int_0x1000000000(self):
+        expected = bytes([0xFF,
+                          0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00])
+        self.assertEqual(expected, encode_var_int(0x1000000000))

--- a/miner/merkle_tree.py
+++ b/miner/merkle_tree.py
@@ -22,6 +22,7 @@ class MerkleTree:
         hashes = list(map(lambda t: to_internal_byte_order(t.hash),
                           transactions))
         self.root = to_rpc_byte_order(self._build_tree(hashes))
+        self.transactions = transactions
 
     def _build_tree(self, hashes):
         """


### PR DESCRIPTION
Takes the data from [this example](https://bitcoin.org/en/developer-reference#submitblock) in the unit-tests to make sure that we produce the same bytes.
