### PR TITLE
Template add hash, coinbase and address

### DIFF
--- a/bitcoin-config/bitcoin3.conf
+++ b/bitcoin-config/bitcoin3.conf
@@ -11,4 +11,3 @@ rpcuser=username
 rpcpassword=password
  # Cory connects to nobody
 addnode=localhost:18444
-

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -90,11 +90,14 @@ export class Server {
       .digest("hex");
 
     const height: string = this.toLittleEndianNumber(template.height);
-    const cb0 = "0" + height.length / 2;        // height size in byte (2 bytes)
+    const cb0 = "0" + height.length / 2;        // height size in byte (1 byte)
     const cb1 = height;                         // height
-    const cb2 = "0".repeat(86 - height.length); // extra nonce
-    const cb3 = "2f503253482f";                 // vote (12 bytes)
+    const cb2 = "0".repeat(186 - height.length);// extra nonce
+    const cb3 = "2f503253482f";                 // vote (6 bytes)
     template.coinbase = cb0 + cb1 + cb2 + cb3;  // coinbase
+
+    assert(template.coinbase.length / 2 >= 2);
+    assert(template.coinbase.length / 2 <= 100);
 
     return template;
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,7 +5,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 import * as zmq from "zmq";
 import {connectToBC} from "./bitcoin_helper";
-import {BlockTemplate, Template} from "./template";
+import {BlockTemplate, Template, ReceivedAddress} from "./template";
 
 export class Server {
   private clients: Array<zmq.Socket>;
@@ -46,7 +46,8 @@ export class Server {
 
     return this.getBlockTemplate()
       .then((template: Template) => {
-        template = this.updateTemplate(template);
+        return this.updateTemplate(template);
+      }).then((template: Template) => {
         this.broadcastTemplate(template);
 
         return this.delay();
@@ -84,22 +85,27 @@ export class Server {
     return sock;
   }
 
-  private updateTemplate(template: Template): Template {
-    template.hash = crypto.createHash("sha256")
-      .update(JSON.stringify(template))
-      .digest("hex");
+  private updateTemplate(template: Template): Promise<Template> {
+    return this.BCClient.listReceivedByAddress(0, true)
+      .then((addresses: Array<ReceivedAddress>) => {
+        template.address = addresses[0].address;
 
-    const height: string = this.toLittleEndianNumber(template.height);
-    const cb0 = "0" + height.length / 2;        // height size in byte (1 byte)
-    const cb1 = height;                         // height
-    const cb2 = "0".repeat(186 - height.length);// extra nonce
-    const cb3 = "2f503253482f";                 // vote (6 bytes)
-    template.coinbase = cb0 + cb1 + cb2 + cb3;  // coinbase
+        const height: string = this.toLittleEndianNumber(template.height);
+        const cb0 = "0" + height.length / 2;        // height size in byte (1 byte)
+        const cb1 = height;                         // height
+        const cb2 = "0".repeat(186 - height.length);// extra nonce
+        const cb3 = "2f503253482f";                 // vote (6 bytes)
+        template.coinbase = cb0 + cb1 + cb2 + cb3;  // coinbase
 
-    assert(template.coinbase.length / 2 >= 2);
-    assert(template.coinbase.length / 2 <= 100);
+        assert(template.coinbase.length / 2 >= 2);
+        assert(template.coinbase.length / 2 <= 100);
 
-    return template;
+        template.hash = crypto.createHash("sha256")
+          .update(JSON.stringify(template))
+          .digest("hex");
+
+        return template;
+      });
   }
 
   // http://stackoverflow.com/a/7946195/1779927

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -89,11 +89,12 @@ export class Server {
       .update(JSON.stringify(template))
       .digest("hex");
 
-    const cb0 = "03";                                       // push
-    const cb1 = this.toLittleEndianNumber(template.height); // height
-    const cb2 = "0".repeat(80);                             // extra nonce
-    const cb3 = "2f503253482f";                             // vote
-    template.coinbase = cb0 + cb1 + cb2 + cb3;              // coinbase
+    const height: string = this.toLittleEndianNumber(template.height);
+    const cb0 = "0" + height.length / 2;        // height size in byte (2 bytes)
+    const cb1 = height;                         // height
+    const cb2 = "0".repeat(86 - height.length); // extra nonce
+    const cb3 = "2f503253482f";                 // vote (12 bytes)
+    template.coinbase = cb0 + cb1 + cb2 + cb3;  // coinbase
 
     return template;
   }

--- a/server/src/template.ts
+++ b/server/src/template.ts
@@ -36,9 +36,19 @@ export class BlockTemplate {
   [key: string]: any;
 }
 
+export interface ReceivedAddress {
+  address: string;
+  account: string;
+  amount: number;
+  confirmations: number;
+  label: string;
+  txids: Array<string>;
+}
+
 export class Template extends BlockTemplate {
   hash: string;
   coinbase: string;
+  address: string;
 
   constructor(obj: BlockTemplate) {
     super();

--- a/server/src/template.ts
+++ b/server/src/template.ts
@@ -37,6 +37,9 @@ export class BlockTemplate {
 }
 
 export class Template extends BlockTemplate {
+  hash: string;
+  coinbase: string;
+
   constructor(obj: BlockTemplate) {
     super();
     for (let propName in obj) {

--- a/server/src/typings/bitcoin-core.d.ts
+++ b/server/src/typings/bitcoin-core.d.ts
@@ -54,10 +54,21 @@ declare module "bitcoin-core" {
       }): Client;
     }
 
+    interface ReceivedAddress {
+      address: string;
+      account: string;
+      amount: number;
+      confirmations: number;
+      label: string;
+      txids: Array<string>;
+    }
+
     interface Client {
       getWork(): any;
       getBlockTemplate(): Promise<BlockTemplate>;
       submitBlock(block: string): Promise<any>;
+      listReceivedByAddress(minConf?:number, includeEmpty?: boolean):
+        Promise<Array<ReceivedAddress>>;
     }
   }
 


### PR DESCRIPTION
Add hash, coinbase and address to the template.

Currently, those are the added fields

``` json
 address: 'myCZgboMeEXLxipKSm5AXtskGdASVQHGsi',
  coinbase: '016600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002f503253482f',
  hash: '3f2c5eb8f6b0b7c7c47444544fad4b776fe2f0d911bec20c7996daa1ee4cf9f5'
```

Fix many issues from last commits.
- Add coinbase size assert
- Fix some general size issues
