### PR TITLE
Public Key Hash Extraction From Address

### DIFF
--- a/miner/Makefile
+++ b/miner/Makefile
@@ -7,4 +7,4 @@ test:
 	python -m $(UNIT_TESTS)
 
 coverage:
-	coverage run -m --branch $(UNIT_TESTS)
+	coverage run --source . -m --branch $(UNIT_TESTS)

--- a/miner/address.py
+++ b/miner/address.py
@@ -1,0 +1,19 @@
+from base58 import b58decode_check
+
+
+def p2pkh_address_to_pubkey_hash(address):
+    """
+    Takes a P2PKH address (starting with a 1, m or n symbol) and extracts its
+    HASH160 hash (used as a public key hash).
+
+    :see: https://en.bitcoin.it/wiki/List_of_address_prefixes
+
+    :param address: P2PKH public address
+    :returns:       HASH160 hash of the public key
+    """
+    decoded = b58decode_check(address)
+
+    # check that it is a mainnet or testnet P2PKH address,
+    assert(decoded[0] in [0x00, 0x6F])
+
+    return decoded[1:]

--- a/miner/address.py
+++ b/miner/address.py
@@ -16,4 +16,4 @@ def p2pkh_address_to_pubkey_hash(address):
     # check that it is a mainnet or testnet P2PKH address
     assert(decoded[0] in [0x00, 0x6F])
 
-    return decoded[1:]
+    return decoded[1:]  # skip version byte

--- a/miner/address.py
+++ b/miner/address.py
@@ -13,7 +13,7 @@ def p2pkh_address_to_pubkey_hash(address):
     """
     decoded = b58decode_check(address)
 
-    # check that it is a mainnet or testnet P2PKH address,
+    # check that it is a mainnet or testnet P2PKH address
     assert(decoded[0] in [0x00, 0x6F])
 
     return decoded[1:]

--- a/miner/address_test.py
+++ b/miner/address_test.py
@@ -1,0 +1,17 @@
+import unittest
+
+from address import p2pkh_address_to_pubkey_hash
+
+
+class AddressTest(unittest.TestCase):
+    def test_address_p2pkh_to_pubkey_hash_mainnet(self):
+        # taken from:
+        # https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
+        addr = "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM"
+        expected = bytes.fromhex(
+            "010966776006953D5567439E5E39F86A0D273BEE"
+        )
+
+        hash_ = p2pkh_address_to_pubkey_hash(addr)
+
+        self.assertEqual(expected, hash_)

--- a/miner/requirements.txt
+++ b/miner/requirements.txt
@@ -1,3 +1,4 @@
 coverage
 coveralls
 pyzmq
+base58


### PR DESCRIPTION
Takes an address (e.g. `16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM`) and decodes the public key hash (HASH160) contained within it using an outside [`Base58Check`](https://en.bitcoin.it/wiki/Base58Check_encoding) library.
